### PR TITLE
Added the salon creation flow

### DIFF
--- a/salon_creator/ios/Podfile.lock
+++ b/salon_creator/ios/Podfile.lock
@@ -265,7 +265,7 @@ PODS:
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.3.0):
+  - FirebaseCoreDiagnostics (8.4.0):
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
@@ -441,7 +441,7 @@ SPEC CHECKSUMS:
   firebase_storage: 0569941c22a1362f682ebef93755d8916601d22f
   FirebaseAuth: fd12c82de44e7ad3b821610c387b8251f03aa0f9
   FirebaseCore: a6dba751680d7033b9d3831e1cfc95ead0605118
-  FirebaseCoreDiagnostics: 7e873baabcfaa9512f538554ae4fa0817aaafbdb
+  FirebaseCoreDiagnostics: cad03be1904b975f845e632f2720c3337da27faf
   FirebaseFirestore: f4f42828c6d82f6945575611c23dd343e0e7d0aa
   FirebaseFunctions: f391cdeef45d2e85ef4e16a6ecca05f30e162c41
   FirebaseStorage: ff380720c204593d98c3e5482e62ccfbb522f0c5

--- a/salon_creator/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/salon_creator/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/salon_creator/ios/Runner/Info.plist
+++ b/salon_creator/ios/Runner/Info.plist
@@ -30,7 +30,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.911023633551-ikue0k2o9bpmf6cane2rn011g6dj2fiv</string>
+				<string>com.googleusercontent.apps.649411725532-110sj4lkvb4b7p4u9938b8pop9t1dmm0</string>
 			</array>
 		</dict>
 	</array>

--- a/salon_creator/lib/app.dart
+++ b/salon_creator/lib/app.dart
@@ -32,7 +32,12 @@ class SalonCreatorApp extends StatelessWidget {
       home: StreamBuilder(
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (ctx, snapshot) {
-          if (snapshot.hasData) {
+          final User user = snapshot.data;
+          if (snapshot.hasData &&
+              FirebaseFirestore.instance
+                      .collection(DbHandler.usersCollection)
+                      .doc(user.email) ==
+                  null) {
             return _buildHomePage();
           }
           return LoginScreen();
@@ -76,18 +81,14 @@ class SalonCreatorApp extends StatelessWidget {
         if (!snapshot.hasData) {
           return LinearProgressIndicator();
         }
-        FirebaseAuth.instance.authStateChanges().listen(
-          (User user) {
-            if (user != null) {
-              if (snapshot.data.exists &&
-                  snapshot.data.get(FieldPath(['role'])) == 1) {
-                return HomePage();
-              } else if (snapshot.data.get(FieldPath(['role'])) == 0) {
-                return SalonRegistrationScreen();
-              }
-            }
-          },
-        );
+
+        if (snapshot.data.exists &&
+            snapshot.data.get(FieldPath(['role'])) == 1) {
+          return HomePage();
+        } else if (snapshot.data.get(FieldPath(['role'])) == 0) {
+          return SalonRegistrationScreen();
+        }
+
         return LoginScreen();
       },
     );

--- a/salon_creator/lib/firebase/database.dart
+++ b/salon_creator/lib/firebase/database.dart
@@ -28,18 +28,10 @@ class DbHandler {
     return dbObject != null ? UserModel.fromMap(dbObject.data()) : null;
   }
 
-  Future addSalon(Salon salon) async {
-    try {
-      await salonCollectionRef
-          .withConverter(
-            fromFirestore: (snapshot, _) => Salon.fromMap(snapshot.data()),
-            toFirestore: (salon, _) => salon.toMap(),
-          )
-          .add(salon);
-    } on FirebaseException catch (e) {
-      print(e.message);
-    }
-  }
+  Future addSalon(Salon salon) async => await FirebaseFirestore.instance
+      .collection("salons")
+      .doc()
+      .set(salon.toMap());
 
   Future getSalon(User user) async => await salonCollectionRef
       .where(['owner'], isEqualTo: user.email)

--- a/salon_creator/lib/firebase/database.dart
+++ b/salon_creator/lib/firebase/database.dart
@@ -54,17 +54,13 @@ class StorageHandler {
     imageFileRef = FirebaseStorage.instance.ref().child(imageFilePath);
   }
 
-  Future uploadMediaFilesAndGetUrls(List<XFile> mediaFiles) async {
-    var snapshot = imageFileRef;
-    List<String> donwloadUrl = [];
-    for (int i = 0; i < mediaFiles.length; i++) {
-      final url = await snapshot
-          .child('${Uuid().v1()}.png')
-          .putFile(File(mediaFiles[i].path));
-      donwloadUrl.add(
-        await url.ref.getDownloadURL(),
-      );
-    }
-    return donwloadUrl;
+  Future<String> uploadImageAndGetUrl(File file) async {
+    var snapshot = await FirebaseStorage.instance
+        .ref()
+        .child('images')
+        .child('${Uuid().v1()}.png')
+        .putFile(file);
+
+    return snapshot.ref.getDownloadURL();
   }
 }

--- a/salon_creator/lib/firebase/database.dart
+++ b/salon_creator/lib/firebase/database.dart
@@ -1,7 +1,12 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:salon_creator/models/salon.dart';
 import 'package:salon_creator/models/user_model.dart';
+import 'package:uuid/uuid.dart';
 
 class DbHandler {
   static final String usersCollection = 'users';
@@ -38,4 +43,28 @@ class DbHandler {
       .get()
       .docs
       .first;
+}
+
+class StorageHandler {
+  static final String imageFilePath = "images";
+
+  var imageFileRef;
+
+  StorageHandler() {
+    imageFileRef = FirebaseStorage.instance.ref().child(imageFilePath);
+  }
+
+  Future uploadMediaFilesAndGetUrls(List<XFile> mediaFiles) async {
+    var snapshot = imageFileRef;
+    List<String> donwloadUrl = [];
+    for (int i = 0; i < mediaFiles.length; i++) {
+      final url = await snapshot
+          .child('${Uuid().v1()}.png')
+          .putFile(File(mediaFiles[i].path));
+      donwloadUrl.add(
+        await url.ref.getDownloadURL(),
+      );
+    }
+    return donwloadUrl;
+  }
 }

--- a/salon_creator/lib/models/salon.dart
+++ b/salon_creator/lib/models/salon.dart
@@ -1,7 +1,7 @@
 class Salon {
   String owner;
   String name;
-  List media;
+  List<String> media;
   String category;
   String description;
   String price;

--- a/salon_creator/lib/models/salon.dart
+++ b/salon_creator/lib/models/salon.dart
@@ -1,11 +1,13 @@
 class Salon {
+  String owner;
   String name;
-  String media;
+  List media;
   String category;
   String description;
   String price;
 
   Salon({
+    this.owner,
     this.name,
     this.media,
     this.category,
@@ -15,19 +17,21 @@ class Salon {
 
   Map<String, dynamic> toMap() {
     return {
+      'owner': this.owner,
       'name': this.name,
       'category': this.category,
       'description': this.description,
       'price': this.price,
-      'media': this.media,
+      'media': List.castFrom(media),
     };
   }
 
   Salon.fromMap(Map<String, dynamic> map) {
-    this.name = map[this.name];
-    this.category = map[this.category];
-    this.description = map[this.description];
-    this.price = map[this.price];
-    this.media = map[this.media];
+    this.owner = map['owner'];
+    this.name = map['name'];
+    this.category = map['category'];
+    this.description = map['description'];
+    this.price = map['price'];
+    this.media = map['media'];
   }
 }

--- a/salon_creator/lib/models/user_model.dart
+++ b/salon_creator/lib/models/user_model.dart
@@ -31,13 +31,13 @@ class UserModel {
   }
 
   UserModel.fromMap(Map<String, dynamic> map)
-      : assert(map['email'] != null),
-        assert(map['role'] != null),
-        email = map['email'],
+      : email = map['email'],
         role = RoleType.values[map['role']],
-        settings = UserSettings.fromMap(map['setting'].cast<String, dynamic>()),
+        settings = UserSettings.fromMap(map['setting']),
+        // .cast<String, dynamic>()
         created = map['created'].toDate(),
-        profile = UserProfileModel.fromMap(map['profile'].cast<String, dynamic>());
+        profile = UserProfileModel.fromMap(map['profile']);
+  // .cast<String, dynamic>());
 }
 
 enum RoleType {

--- a/salon_creator/lib/models/user_model.dart
+++ b/salon_creator/lib/models/user_model.dart
@@ -30,14 +30,14 @@ class UserModel {
     return (role == RoleType.creator);
   }
 
+//Cast occurs error
   UserModel.fromMap(Map<String, dynamic> map)
       : email = map['email'],
         role = RoleType.values[map['role']],
-        settings = UserSettings.fromMap(map['setting']),
-        // .cast<String, dynamic>()
+        settings = UserSettings.fromMap(map['setting'].cast<String, dynamic>()),
         created = map['created'].toDate(),
-        profile = UserProfileModel.fromMap(map['profile']);
-  // .cast<String, dynamic>());
+        profile =
+            UserProfileModel.fromMap(map['profile'].cast<String, dynamic>());
 }
 
 enum RoleType {

--- a/salon_creator/lib/screens/login_screen.dart
+++ b/salon_creator/lib/screens/login_screen.dart
@@ -161,8 +161,9 @@ class _LoginScreenState extends State<LoginScreen> {
     DbHandler dbHandler = DbHandler();
     final User user = FirebaseAuth.instance.currentUser;
 
+    //エラー可能性
     if (user != null) {
-      if (dbHandler.getUser(user.email) != null) {
+      if (await dbHandler.getUser(user.email) != null) {
         return;
       }
       assert(!user.isAnonymous);

--- a/salon_creator/lib/screens/login_screen.dart
+++ b/salon_creator/lib/screens/login_screen.dart
@@ -162,12 +162,11 @@ class _LoginScreenState extends State<LoginScreen> {
     final User user = FirebaseAuth.instance.currentUser;
 
     if (user != null) {
-      assert(!user.isAnonymous);
-      assert(await user.getIdToken() != null);
-
-      if (await dbHandler.getUser(user.email) != null) {
+      if (dbHandler.getUser(user.email) != null) {
         return;
       }
+      assert(!user.isAnonymous);
+      assert(await user.getIdToken() != null);
 
       dbHandler
           .addUser(UserModel(
@@ -206,6 +205,7 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   void _tryLoginWith(BuildContext context, method) async {
+    final User user = FirebaseAuth.instance.currentUser;
     setState(() {
       _loginInProgress = true;
     });

--- a/salon_creator/lib/screens/salon_creation_screen.dart
+++ b/salon_creator/lib/screens/salon_creation_screen.dart
@@ -1,4 +1,16 @@
+import 'dart:io';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:salon_creator/common/color.dart';
+import 'package:salon_creator/firebase/database.dart';
+import 'package:salon_creator/models/salon.dart';
+import 'package:salon_creator/widgets/custom_button.dart';
+import 'package:salon_creator/widgets/custom_dialog.dart';
+import 'package:salon_creator/widgets/custom_label.dart';
+import 'package:salon_creator/widgets/custom_textfield.dart';
+import 'package:uuid/uuid.dart';
 
 class SalonCreationScreen extends StatefulWidget {
   const SalonCreationScreen({Key key}) : super(key: key);
@@ -8,20 +20,529 @@ class SalonCreationScreen extends StatefulWidget {
 }
 
 class _SalonCreationScreenState extends State<SalonCreationScreen> {
+  bool isFilled = false;
+  bool inProgress = false;
+  final ImagePicker imagePicker = ImagePicker();
+  int index = 0;
+  List<XFile> _imageFiles = [];
+
+  ScrollController _scrollController = ScrollController();
+  TextEditingController categoriesController = TextEditingController();
+  TextEditingController descriptionController = TextEditingController();
+  TextEditingController priceController = TextEditingController();
+  TextEditingController salonNameController = TextEditingController();
+  XFile image;
+
+  void _updateScreenContext() {
+    var _hasProfileChanged = salonNameController.text.isNotEmpty &&
+        categoriesController.text.isNotEmpty &&
+        descriptionController.text.isNotEmpty &&
+        priceController.text.isNotEmpty &&
+        _imageFiles.isNotEmpty;
+    print(salonNameController.text.isNotEmpty);
+
+    print(priceController.text.isNotEmpty);
+    print(descriptionController.text.isNotEmpty);
+    print(categoriesController.text.isNotEmpty);
+    print(_imageFiles.isNotEmpty);
+    print(isFilled);
+
+    setState(() {
+      isFilled = _hasProfileChanged;
+    });
+  }
+
+  _scrollToRight() {
+    _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context).size;
+    final screenWidth = mq.width;
+    final screenHeight = mq.height;
+
     return Scaffold(
-      appBar: AppBar(
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pushReplacementNamed('/home');
-            },
-            child: Text("スキップ"),
+      appBar: inProgress ? null : _buildAppBar(context),
+      body: inProgress
+          ? _buildCreatingProgressScreen()
+          : SafeArea(
+              child: GestureDetector(
+                onTap: () {
+                  FocusScope.of(context).unfocus();
+                },
+                child: SingleChildScrollView(
+                  child: Container(
+                    child: Column(
+                      children: [
+                        SizedBox(
+                          height: 8,
+                        ),
+                        _buildMediaPreviewerDivider(),
+                        SizedBox(
+                          height: 8,
+                        ),
+                        _buildMediaPreviewer(
+                            screenHeight, screenWidth, context),
+                        _buildMediaPane(context),
+                        _buildSalonDetailForms(screenWidth),
+                        isFilled ? Container() : Text("空欄の部分があります"),
+                        _buildSalonSaveButton(screenWidth, screenHeight),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+
+  Center _buildCreatingProgressScreen() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            "作成中です",
+            style: TextStyle(
+              color: primaryColor,
+            ),
           ),
+          SizedBox(
+            height: 16,
+          ),
+          CircularProgressIndicator(),
         ],
-        title: Text("サロン作成"),
       ),
     );
+  }
+
+  Widget _buildMediaPreviewerDivider() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text("プレビュー用メディア"),
+      ],
+    );
+  }
+
+  Widget _buildSalonSaveButton(double screenWidth, double screenHeight) {
+    return CustomButton(
+      function: isFilled
+          ? () async {
+              setState(() {
+                inProgress = true;
+              });
+              await saveSalonDetail().whenComplete(() {
+                setState(() {
+                  inProgress = false;
+                });
+                Navigator.of(context).pushReplacementNamed('/home');
+              });
+            }
+          : null,
+      text: "保存",
+      width: screenWidth * 0.4,
+      height: screenHeight * 0.05,
+    );
+  }
+
+  Widget _buildMediaPane(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Color.fromRGBO(195, 195, 195, 0.3),
+      ),
+      margin: EdgeInsets.only(top: 8),
+      height: 48,
+      child: Center(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            _buildMediaPaneAddButton(context),
+            _imageFiles != null ? _buildMediaPaneIconList() : Container(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMediaPaneIconList() {
+    return Expanded(
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        controller: _scrollController,
+        itemCount: _imageFiles.length,
+        itemBuilder: (BuildContext context, i) {
+          return Stack(
+            alignment: Alignment.center,
+            children: [
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8),
+                child: _buildMediaPaneIcon(i),
+              ),
+              index == i
+                  ? Container(
+                      width: 80,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: primaryColor,
+                          width: 3,
+                        ),
+                      ),
+                    )
+                  : Container(
+                      width: 80,
+                      height: 48,
+                      child: GestureDetector(
+                        onTap: () {
+                          setState(() {
+                            index = i;
+                          });
+                        },
+                      ),
+                    ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildMediaPaneIcon(int i) {
+    return Stack(
+      alignment: Alignment.topRight,
+      clipBehavior: Clip.antiAliasWithSaveLayer,
+      children: [
+        Image(
+          fit: BoxFit.cover,
+          width: 80,
+          height: 45,
+          image: FileImage(
+            File(
+              _imageFiles[i].path,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMediaPaneAddButton(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: primaryColor,
+        border: Border.all(
+          color: primaryColor,
+          width: 2,
+        ),
+      ),
+      child: IconButton(
+        alignment: Alignment.center,
+        icon: Icon(
+          Icons.add_circle,
+          size: 28,
+          color: Colors.white,
+        ),
+        onPressed: () {
+          showBottomSheet(context);
+        },
+      ),
+    );
+  }
+
+  Widget _buildMediaPreviewer(
+      double screenHeight, double screenWidth, BuildContext context) {
+    return Container(
+      color: Color.fromRGBO(195, 195, 195, 0.3),
+      height: screenWidth * 0.563,
+      width: screenWidth,
+      child: _imageFiles.isEmpty
+          ? TextButton(
+              child: Icon(
+                Icons.add_circle,
+                size: 64,
+                color: primaryColor,
+              ),
+              onPressed: () {
+                showBottomSheet(context);
+              },
+            )
+          : Stack(
+              alignment: Alignment.topLeft,
+              children: [
+                Image(
+                  height: screenWidth * 0.563,
+                  width: screenWidth,
+                  fit: BoxFit.cover,
+                  image: FileImage(
+                    File(
+                      _imageFiles[index].path,
+                    ),
+                  ),
+                ),
+                _buildDeleteButton(context),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildDeleteButton(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      margin: EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: primaryColor,
+        shape: BoxShape.circle,
+      ),
+      child: IconButton(
+        onPressed: () {
+          _buildDeleteConfirmationDialog(context);
+        },
+        icon: Icon(
+          Icons.close,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+
+  void _buildDeleteConfirmationDialog(BuildContext context) {
+    return showCustomDialog(
+      context: context,
+      title: Text(
+        "本当に削除しますか?",
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: 18,
+        ),
+      ),
+      content: "選択されている画像・動画が削除されます",
+      leftButtonText: "削除する",
+      leftFunction: () {
+        setState(() {
+          _imageFiles.removeAt(index);
+          index -= 1;
+        });
+        Navigator.of(context).pop();
+      },
+      rightButtonText: "取り消し",
+      rightFunction: () {
+        Navigator.of(context).pop();
+      },
+    );
+  }
+
+  void showBottomSheet(BuildContext context) async {
+    return await showModalBottomSheet(
+      context: context,
+      builder: (_) {
+        return Container(
+          height: 200,
+          child: Column(
+            children: [
+              ListTile(
+                title: Text("写真を選ぶ"),
+                onTap: () async {
+                  await _storeMediaFiles(context);
+                },
+              ),
+              Divider(
+                height: 0,
+              ),
+              ListTile(
+                title: Text("動画から選ぶ"),
+              ),
+              Divider(
+                height: 0,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSalonDetailForms(double screenWidth) {
+    return Container(
+      margin: EdgeInsets.symmetric(
+        horizontal: screenWidth * 0.05,
+      ),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 16,
+          ),
+          _buildSalonNameForm(),
+          Divider(
+            height: 32,
+          ),
+          _buildCategoryForm(),
+          Divider(
+            height: 32,
+          ),
+          _buildContentForm(),
+          _buildSalonPriceForm(),
+          Divider(
+            height: 40,
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSalonNameForm() {
+    return TextFieldWithLabel(
+      onChanged: (_) => _updateScreenContext(),
+      controller: salonNameController,
+      title: "サロン名",
+      hintText: "ゴスペルサロン",
+    );
+  }
+
+  Widget _buildCategoryForm() {
+    return TextFieldWithLabel(
+      onChanged: (_) => _updateScreenContext(),
+      controller: categoriesController,
+      title: "カテゴリー",
+      hintText: "ゴスペル、ピアノ、ギター等",
+    );
+  }
+
+  Widget _buildAppBar(BuildContext context) {
+    return AppBar(
+      actions: [
+        TextButton(
+          onPressed: () {
+            final dbHandler = DbHandler();
+            dbHandler.addSalon(
+              Salon(
+                owner: FirebaseAuth.instance.currentUser.email,
+              ),
+            );
+            Navigator.of(context).pushReplacementNamed('/home');
+          },
+          child: Text("スキップ"),
+        ),
+      ],
+      title: Text("サロン作成"),
+    );
+  }
+
+  Widget _buildSalonPriceForm() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        TextFieldWithLabel(
+          onChanged: (_) => _updateScreenContext(),
+          controller: priceController,
+          title: "月額料金",
+          hintText: "1000",
+          width: 100,
+          keyboardType: TextInputType.number,
+        ),
+        SizedBox(
+          width: 8,
+        ),
+        Text(
+          "¥",
+          style: TextStyle(fontSize: 24),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildContentForm() {
+    return Column(
+      children: [
+        CustomLabel(
+          title: "説明文",
+        ),
+        SizedBox(
+          height: 12,
+        ),
+        _buildDescriptionTextField(),
+      ],
+    );
+  }
+
+  Widget _buildDescriptionTextField() {
+    return Container(
+      height: 216,
+      child: TextField(
+        onChanged: (_) => _updateScreenContext(),
+        controller: descriptionController,
+        textAlignVertical: TextAlignVertical.center,
+        keyboardType: TextInputType.multiline,
+        maxLength: 300,
+        maxLines: 100,
+        style: TextStyle(
+          fontSize: 16,
+        ),
+        decoration: InputDecoration(
+          contentPadding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: Colors.black,
+              width: 0.5,
+            ),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: Colors.black,
+              width: 0.5,
+            ),
+          ),
+          hintText: "サロンの目的、発信内容等",
+        ),
+      ),
+    );
+  }
+
+  Future saveSalonDetail() async {
+    final dbHandle = DbHandler();
+    Salon salon = Salon();
+    salon.category = categoriesController.text;
+    salon.description = descriptionController.text;
+    salon.name = salonNameController.text;
+    salon.owner = FirebaseAuth.instance.currentUser.email;
+    salon.price = priceController.text;
+    if (_imageFiles.isNotEmpty) {
+      salon.media = await _uploadImageAndGetUrl();
+    }
+    await dbHandle.addSalon(salon);
+  }
+
+  Future<void> _storeMediaFiles(BuildContext context) async {
+    try {
+      Navigator.of(context).pop();
+      final pickedFile =
+          await imagePicker.pickImage(source: ImageSource.gallery);
+
+      setState(() {
+        _imageFiles.add(pickedFile);
+        index = _imageFiles.length - 1;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToRight());
+      _updateScreenContext();
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future _uploadImageAndGetUrl() async {
+    var snapshot = FirebaseStorage.instance.ref().child('images');
+    List donwloadUrl = [];
+    for (int i = 0; i < _imageFiles.length; i++) {
+      final url = await snapshot
+          .child('${Uuid().v1()}.png')
+          .putFile(File(_imageFiles[i].path));
+      donwloadUrl.add(
+        await url.ref.getDownloadURL(),
+      );
+    }
+
+    return donwloadUrl;
   }
 }

--- a/salon_creator/lib/screens/salon_creation_screen.dart
+++ b/salon_creator/lib/screens/salon_creation_screen.dart
@@ -515,9 +515,15 @@ class _SalonCreationScreenState extends State<SalonCreationScreen> {
     salon.name = salonNameController.text;
     salon.owner = FirebaseAuth.instance.currentUser.email;
     salon.price = priceController.text;
+    salon.media = [];
     if (_imageFiles.isNotEmpty) {
-      salon.media =
-          await storageHandler.uploadMediaFilesAndGetUrls(_imageFiles);
+      for (int i = 0; i < _imageFiles.length; i++) {
+        salon.media.add(
+          await storageHandler.uploadImageAndGetUrl(
+            File(_imageFiles[i].path),
+          ),
+        );
+      }
     }
     await dbHandler.addSalon(salon);
   }

--- a/salon_creator/lib/widgets/custom_textfield.dart
+++ b/salon_creator/lib/widgets/custom_textfield.dart
@@ -2,17 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:salon_creator/widgets/custom_label.dart';
 
 class TextFieldWithLabel extends StatefulWidget {
-  const TextFieldWithLabel({
-    Key key,
-    this.controller,
-    this.height,
-    this.width,
-    this.keyboardType,
-    this.title,
-    this.labelWidth,
-    this.labelHeight,
-    this.hintText,
-  }) : super(key: key);
+  const TextFieldWithLabel(
+      {Key key,
+      this.controller,
+      this.height,
+      this.width,
+      this.keyboardType,
+      this.title,
+      this.labelWidth,
+      this.labelHeight,
+      this.hintText,
+      this.maxLength,
+      this.onChanged,
+      this.maxLines})
+      : super(key: key);
+
+  final int maxLength;
+  final int maxLines;
   final TextEditingController controller;
   final double height;
   final double width;
@@ -21,6 +27,7 @@ class TextFieldWithLabel extends StatefulWidget {
   final double labelWidth;
   final double labelHeight;
   final String hintText;
+  final Function onChanged;
 
   @override
   _TextFieldWithLabelState createState() => _TextFieldWithLabelState();
@@ -52,14 +59,16 @@ class _TextFieldWithLabelState extends State<TextFieldWithLabel> {
     return Container(
       height: 32,
       child: TextField(
+        onChanged: widget.onChanged,
+        maxLines: widget.maxLines,
+        maxLength: widget.maxLength,
         controller: widget.controller,
         keyboardType: widget.keyboardType,
         style: TextStyle(
-          height: 1,
           fontSize: 16,
         ),
         decoration: InputDecoration(
-          contentPadding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+          contentPadding: EdgeInsets.fromLTRB(16, 0, 16, 0),
           focusedBorder: OutlineInputBorder(
             borderSide: BorderSide(
               color: Colors.black,


### PR DESCRIPTION
https://youtu.be/nJ8gmkC65mw 
<img width="1440" alt="スクリーンショット 2021-08-05 12 31 24" src="https://user-images.githubusercontent.com/11326195/128286589-f4e2af12-00a9-4220-a338-60148ab6adef.png">

I added a function to add media files and upload them to both firestore and cloud storage.
And also, when an item is added to a list that is not on the screen, automatically scrolls to a position of the latest item.
Users can only delete items from the media previewer, however, I'm considering adding a delete button at the corner of each item in the media pane.
Added a function to check if none of the fields are empty which is what you've told me before.
I haven't added a function to change the order of items in the media pane. 
And when users tap the skip button, only users' email will be added into firestore so that they reach the home screen instead of the salon creation screen when they open the application after they skip the salon creation.